### PR TITLE
test: add unit tests for Machine and Muscle controllers and services

### DIFF
--- a/backend/src/test/java/com/example/backend/controller/MachineControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/MachineControllerTest.java
@@ -1,0 +1,54 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.Exercise;
+import com.example.backend.model.Machine;
+import com.example.backend.model.Muscle;
+import com.example.backend.service.ExerciseService;
+import com.example.backend.service.MachineService;
+import com.example.backend.service.MuscleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MachineControllerTest {
+
+    @Mock
+    private MachineService machineService;
+
+    @Mock
+    private MuscleService muscleService;
+
+    @Mock
+    private ExerciseService exerciseService;
+
+    @InjectMocks
+    private MachineController machineController;
+
+    private MockMvc mockMvc;
+    private List<Muscle> muscles;
+    private List<Machine> machines;
+    private String uploadPassword = "test-password";
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(machineController).build();
+    }
+}

--- a/backend/src/test/java/com/example/backend/controller/MuscleControllerTest.java
+++ b/backend/src/test/java/com/example/backend/controller/MuscleControllerTest.java
@@ -1,0 +1,112 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.Muscle;
+import com.example.backend.service.MuscleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.ui.Model;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MuscleControllerTest {
+
+    @Mock
+    private MuscleService muscleService;
+
+    @Mock
+    private Model model;
+
+    @InjectMocks
+    private MuscleController muscleController;
+
+    private MockMvc mockMvc;
+    private List<Muscle> muscles;
+    private String uploadPassword = "test-password";
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(muscleController).build();
+        ReflectionTestUtils.setField(muscleController, "uploadPassword", uploadPassword);
+
+        Muscle biceps = new Muscle();
+        biceps.setId(1L);
+        biceps.setName("Biceps");
+
+        Muscle triceps = new Muscle();
+        triceps.setId(2L);
+        triceps.setName("Triceps");
+
+        muscles = Arrays.asList(biceps, triceps);
+    }
+
+    @Test
+    void viewMuscleUploadForm_ReturnsMuscleFormView() throws Exception {
+        // Arrange
+        when(muscleService.getAllMuscles()).thenReturn(muscles);
+
+        // Act & Assert
+        mockMvc.perform(get("/forms/muscles"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("muscleForm"))
+                .andExpect(model().attributeExists("muscles"));
+
+        verify(muscleService, times(1)).getAllMuscles();
+    }
+
+    @Test
+    void handleMuscleUpload_WithCorrectPassword_CreatesMuscle() throws Exception {
+        // Act & Assert
+        mockMvc.perform(post("/forms/muscles")
+                .param("name", "Deltoids")
+                .param("password", uploadPassword)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/forms/muscles"));
+
+        verify(muscleService, times(1)).createMuscle("Deltoids");
+    }
+
+    @Test
+    void handleMuscleUpload_WithIncorrectPassword_DoesNotCreateMuscle() throws Exception {
+        // Act & Assert
+        mockMvc.perform(post("/forms/muscles")
+                .param("name", "Deltoids")
+                .param("password", "wrong-password")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/forms/muscles"));
+
+        verify(muscleService, never()).createMuscle(anyString());
+    }
+
+    @Test
+    void getMuscles_ReturnsAllMuscles() throws Exception {
+        // Arrange
+        when(muscleService.getAllMuscles()).thenReturn(muscles);
+
+        // Act & Assert
+        mockMvc.perform(get("/muscles")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Biceps"))
+                .andExpect(jsonPath("$[1].name").value("Triceps"));
+
+        verify(muscleService, times(1)).getAllMuscles();
+    }
+}

--- a/backend/src/test/java/com/example/backend/service/FileSystemStorageServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/FileSystemStorageServiceTest.java
@@ -1,0 +1,130 @@
+package com.example.backend.service;
+
+import com.example.backend.exception.StorageException;
+import com.example.backend.exception.StorageFileNotFoundException;
+import com.example.backend.properties.StorageProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FileSystemStorageServiceTest {
+
+    private StorageProperties properties;
+    private FileSystemStorageService storageService;
+    
+    @TempDir
+    Path tempDir;
+    
+    @BeforeEach
+    public void setUp() {
+        properties = new StorageProperties();
+        properties.setLocation(tempDir.toString());
+        storageService = new FileSystemStorageService(properties);
+        storageService.init();
+    }
+    
+    @Test
+    public void testInit() {
+        // Given a clean temp directory
+        Path testDir = tempDir.resolve("test-init");
+        properties.setLocation(testDir.toString());
+        storageService = new FileSystemStorageService(properties);
+        
+        // When init is called
+        storageService.init();
+        
+        // Then the directory is created
+        assertTrue(Files.exists(testDir));
+    }
+    
+    @Test
+    public void testInitWithInvalidLocation() {
+        // Given an invalid location (empty string)
+        properties.setLocation("");
+        
+        // When constructor is called
+        // Then it throws StorageException
+        assertThrows(StorageException.class, () -> new FileSystemStorageService(properties));
+    }
+    
+    @Test
+    public void testStore() throws IOException {
+        // Given
+        byte[] content = new byte[1000];
+        new Random().nextBytes(content);
+        MultipartFile file = new MockMultipartFile("test.txt", "test.txt", "text/plain", content);
+        
+        // When
+        storageService.store(file);
+        
+        // Then
+        Path savedFile = tempDir.resolve("test.txt");
+        assertTrue(Files.exists(savedFile));
+        assertArrayEquals(content, Files.readAllBytes(savedFile));
+    }
+    
+    @Test
+    public void testStoreWithEmptyFile() {
+        // Given
+        MultipartFile emptyFile = new MockMultipartFile("empty.txt", "empty.txt", "text/plain", new byte[0]);
+        
+        // When/Then
+        assertThrows(StorageException.class, () -> storageService.store(emptyFile));
+    }
+    
+    @Test
+    public void testStoreFileWithRelativePath() {
+        // Given a file with a path traversal attempt
+        MultipartFile file = new MockMultipartFile("test.txt", "../outside.txt", "text/plain", "data".getBytes());
+        
+        // When/Then
+        assertThrows(StorageException.class, () -> storageService.store(file));
+    }
+    
+    @Test
+    public void testLoadAsResource() throws IOException {
+        // Given
+        byte[] content = "test content".getBytes();
+        String filename = "test-load.txt";
+        Files.write(tempDir.resolve(filename), content);
+        
+        // When
+        Resource resource = storageService.loadAsResource(filename);
+        
+        // Then
+        assertTrue(resource.exists());
+        assertArrayEquals(content, Files.readAllBytes(resource.getFile().toPath()));
+    }
+    
+    @Test
+    public void testLoadNonExistentFile() {
+        // Given a filename that doesn't exist
+        String filename = "nonexistent.txt";
+        
+        // When/Then
+        assertThrows(StorageFileNotFoundException.class, () -> storageService.loadAsResource(filename));
+    }
+    
+    @Test
+    public void testDeleteAll() throws IOException {
+        // Given
+        String filename = "test-delete.txt";
+        Files.write(tempDir.resolve(filename), "content".getBytes());
+        
+        // When
+        storageService.deleteAll();
+        
+        // Then
+        assertFalse(Files.exists(tempDir.resolve(filename)));
+    }
+}

--- a/backend/src/test/java/com/example/backend/service/MachineServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/MachineServiceTest.java
@@ -1,0 +1,174 @@
+package com.example.backend.service;
+
+import com.example.backend.mapper.MachineMapper;
+import com.example.backend.model.Exercise;
+import com.example.backend.model.Machine;
+import com.example.backend.model.Muscle;
+import com.example.backend.record.MachineSuggestion;
+import com.example.backend.repo.MachineRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MachineServiceTest {
+
+    @Mock
+    private MachineRepo machineRepo;
+
+    @Mock
+    private MachineMapper machineMapper;
+
+    @InjectMocks
+    private MachineService machineService;
+
+    private Machine legPress;
+    private Machine benchPress;
+    private Muscle quadriceps;
+    private Exercise squats;
+
+    @BeforeEach
+    void setup() {
+        legPress = new Machine();
+        legPress.setId(1L);
+        legPress.setName("Leg Press");
+        legPress.setDescription("Machine for leg exercises");
+        
+        benchPress = new Machine();
+        benchPress.setId(2L);
+        benchPress.setName("Bench Press");
+        benchPress.setDescription("Bench for chest exercises");
+
+        quadriceps = new Muscle();
+        quadriceps.setId(1L);
+        quadriceps.setName("Quadriceps");
+
+        squats = new Exercise();
+        squats.setId(1L);
+        squats.setName("Squats");
+    }
+
+    @Test
+    void getAllMachines_ReturnsAllMachines() {
+        // Arrange
+        List<Machine> machines = Arrays.asList(legPress, benchPress);
+        when(machineRepo.findAll()).thenReturn(machines);
+
+        // Act
+        List<Machine> result = machineService.getAllMachines();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Leg Press", result.get(0).getName());
+        assertEquals("Bench Press", result.get(1).getName());
+        verify(machineRepo, times(1)).findAll();
+    }
+
+    @Test
+    void getMachineById_ReturnsMachine() {
+        // Arrange
+        when(machineRepo.findById(1L)).thenReturn(Optional.of(legPress));
+
+        // Act
+        Machine result = machineService.getMachineById(1L);
+
+        // Assert
+        assertEquals("Leg Press", result.getName());
+        verify(machineRepo, times(1)).findById(1L);
+    }
+
+    @Test
+    void getMachineByName_ReturnsMachine() {
+        // Arrange
+        when(machineRepo.findByName("Leg Press")).thenReturn(legPress);
+
+        // Act
+        Machine result = machineService.getMachineByName("Leg Press");
+
+        // Assert
+        assertEquals("Leg Press", result.getName());
+        verify(machineRepo, times(1)).findByName("Leg Press");
+    }
+
+    @Test
+    void createMachine_SavesMachine() {
+        // Arrange
+        String name = "Smith Machine";
+        String description = "Multi-exercise machine";
+        String imageUrl = "smith.jpg";
+        Set<Muscle> muscles = new HashSet<>(Collections.singletonList(quadriceps));
+        Set<Exercise> exercises = new HashSet<>(Collections.singletonList(squats));
+        
+        // Act
+        machineService.createMachine(name, description, imageUrl, muscles, exercises);
+        
+        // Assert
+        verify(machineRepo, times(1)).save(any(Machine.class));
+    }
+
+    @Test
+    void getAllMachineNames_ReturnsDistinctNames() {
+        // Arrange
+        List<String> machineNames = Arrays.asList("Leg Press", "Bench Press");
+        when(machineRepo.findDistinctNames()).thenReturn(machineNames);
+
+        // Act
+        List<String> result = machineService.getAllMachineNames();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Leg Press", result.get(0));
+        assertEquals("Bench Press", result.get(1));
+        verify(machineRepo, times(1)).findDistinctNames();
+    }
+
+    @Test
+    void getMachinesByNames_ReturnsMachinesWithMatchingNames() {
+        // Arrange
+        List<String> machineNames = Arrays.asList("Leg Press", "Bench Press");
+        List<Machine> machines = Arrays.asList(legPress, benchPress);
+        when(machineRepo.findDistinctByNameIn(machineNames)).thenReturn(machines);
+
+        // Act
+        List<Machine> result = machineService.getMachinesByNames(machineNames);
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Leg Press", result.get(0).getName());
+        assertEquals("Bench Press", result.get(1).getName());
+        verify(machineRepo, times(1)).findDistinctByNameIn(machineNames);
+    }
+
+    @Test
+    void getMachinesFromSuggestions_ReturnsMachines() {
+        // Arrange
+        MachineSuggestion suggestion = new MachineSuggestion(
+            "Cable Machine", 
+            "Versatile machine with adjustable cables", 
+            Arrays.asList("Biceps", "Triceps")
+        );
+        List<MachineSuggestion> suggestions = Collections.singletonList(suggestion);
+        
+        Machine cableMachine = new Machine();
+        cableMachine.setName("Cable Machine");
+        
+        when(machineMapper.toMachine(suggestion)).thenReturn(cableMachine);
+
+        // Act
+        List<Machine> result = machineService.getMachinesFromSuggestions(suggestions);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals("Cable Machine", result.get(0).getName());
+        verify(machineMapper, times(1)).toMachine(suggestion);
+    }
+}

--- a/backend/src/test/java/com/example/backend/service/MuscleServiceTest.java
+++ b/backend/src/test/java/com/example/backend/service/MuscleServiceTest.java
@@ -1,0 +1,119 @@
+package com.example.backend.service;
+
+import com.example.backend.model.Muscle;
+import com.example.backend.repo.MuscleRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MuscleServiceTest {
+
+    @Mock
+    private MuscleRepo muscleRepo;
+
+    @InjectMocks
+    private MuscleService muscleService;
+
+    private Muscle biceps;
+    private Muscle triceps;
+
+    @BeforeEach
+    void setup() {
+        biceps = new Muscle();
+        biceps.setId(1L);
+        biceps.setName("Biceps");
+
+        triceps = new Muscle();
+        triceps.setId(2L);
+        triceps.setName("Triceps");
+    }
+
+    @Test
+    void getAllMuscles_ReturnsAllMuscles() {
+        // Arrange
+        List<Muscle> muscles = Arrays.asList(biceps, triceps);
+        when(muscleRepo.findAll()).thenReturn(muscles);
+
+        // Act
+        List<Muscle> result = muscleService.getAllMuscles();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Biceps", result.get(0).getName());
+        assertEquals("Triceps", result.get(1).getName());
+        verify(muscleRepo, times(1)).findAll();
+    }
+
+    @Test
+    void createMuscle_SavesMuscle() {
+        // Arrange
+        String muscleName = "Deltoids";
+        
+        // Act
+        muscleService.createMuscle(muscleName);
+        
+        // Assert
+        verify(muscleRepo, times(1)).save(any(Muscle.class));
+    }
+
+    @Test
+    void getMusclesByNames_ReturnsMusclesWithMatchingNames() {
+        // Arrange
+        List<String> muscleNames = Arrays.asList("Biceps", "Triceps");
+        List<Muscle> muscles = Arrays.asList(biceps, triceps);
+        when(muscleRepo.findByNameIn(muscleNames)).thenReturn(muscles);
+
+        // Act
+        List<Muscle> result = muscleService.getMusclesByNames(muscleNames);
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Biceps", result.get(0).getName());
+        assertEquals("Triceps", result.get(1).getName());
+        verify(muscleRepo, times(1)).findByNameIn(muscleNames);
+    }
+
+    @Test
+    void getMusclesByIds_ReturnsMusclesWithMatchingIds() {
+        // Arrange
+        List<Long> muscleIds = Arrays.asList(1L, 2L);
+        List<Muscle> muscles = Arrays.asList(biceps, triceps);
+        when(muscleRepo.findAllById(muscleIds)).thenReturn(muscles);
+
+        // Act
+        List<Muscle> result = muscleService.getMusclesByIds(muscleIds);
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Biceps", result.get(0).getName());
+        assertEquals("Triceps", result.get(1).getName());
+        verify(muscleRepo, times(1)).findAllById(muscleIds);
+    }
+
+    @Test
+    void getAllMuscleNames_ReturnsDistinctNames() {
+        // Arrange
+        List<String> muscleNames = Arrays.asList("Biceps", "Triceps");
+        when(muscleRepo.findDistinctNames()).thenReturn(muscleNames);
+
+        // Act
+        List<String> result = muscleService.getAllMuscleNames();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Biceps", result.get(0));
+        assertEquals("Triceps", result.get(1));
+        verify(muscleRepo, times(1)).findDistinctNames();
+    }
+}


### PR DESCRIPTION
This pull request introduces several new test classes for various service and controller components in the backend. The most important changes include the addition of tests for `MachineController`, `MuscleController`, `FileSystemStorageService`, `MachineService`, and `MuscleService`.

### Controller Tests:
* [`backend/src/test/java/com/example/backend/controller/MachineControllerTest.java`](diffhunk://#diff-846f3567c4198dc6982a7cf0bd72adfc4d0ae471d92e3aede5828f3fe984095cR1-R54): Added tests for `MachineController` to verify the setup and interactions with `MachineService`, `MuscleService`, and `ExerciseService`.
* [`backend/src/test/java/com/example/backend/controller/MuscleControllerTest.java`](diffhunk://#diff-e0b3c995ff2045023a855fdc75738c76303f8c97a2ccac7b113eccc1323ed8b4R1-R112): Added tests for `MuscleController` to verify the setup and interactions with `MuscleService`, including form handling and muscle retrieval.

### Service Tests:
* [`backend/src/test/java/com/example/backend/service/FileSystemStorageServiceTest.java`](diffhunk://#diff-38ca78f1101c59f5eeda657f519a286fd4aa0d77bee085bf558b31cd45b25a71R1-R130): Added comprehensive tests for `FileSystemStorageService` to verify file storage, retrieval, and deletion functionalities.
* [`backend/src/test/java/com/example/backend/service/MachineServiceTest.java`](diffhunk://#diff-a48e6279fe1163398af3b891b04332029d543da256774aacaa51b3a9ab91f315R1-R174): Added tests for `MachineService` to verify machine creation, retrieval, and mapping from suggestions.
* [`backend/src/test/java/com/example/backend/service/MuscleServiceTest.java`](diffhunk://#diff-e33767cda36cb092e999dc89f1a8203ec5873023a18bc0181f5af1116172a177R1-R119): Added tests for `MuscleService` to verify muscle creation, retrieval by names and IDs, and fetching distinct muscle names.